### PR TITLE
13 refactorfastapi lifespan and mocking

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ from src.api.main import app, ml_models
 
 client = TestClient(app)
 
+
 # Mocked successful prediction test
 def test_predict_endpoint_mocked_success():
     """
@@ -13,23 +14,34 @@ def test_predict_endpoint_mocked_success():
     2. Inject this fake model into the API's global model storage
     """
     fake_model = MagicMock()
-    fake_model.predict.return_value = [25.0] # Mock response
+    fake_model.predict.return_value = [25.0]  # Mock response
 
     # Injection of fake model
     # patch.dict replaces the 'ml_models' dict temporarily
     with patch.dict(ml_models, {"model": fake_model}):
         payload = {
-            "CRIM": 0.1, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
-            "NOX": 0.538, "RM": 6.575, "AGE": 65.2, "DIS": 4.09,
-            "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.98
+            "CRIM": 0.1,
+            "ZN": 18.0,
+            "INDUS": 2.31,
+            "CHAS": 0.0,
+            "NOX": 0.538,
+            "RM": 6.575,
+            "AGE": 65.2,
+            "DIS": 4.09,
+            "RAD": 1,
+            "TAX": 296,
+            "PTRATIO": 15.3,
+            "B": 396.9,
+            "LSTAT": 4.98,
         }
-        
+
         response = client.post("/predict", json=payload)
-        
+
         assert response.status_code == 200
         assert response.json() == {"predicted_price": 25.0}
         # Verify that the model's predict method was called once
         fake_model.predict.assert_called_once()
+
 
 # Failure case: Mock of a model that raises an exception
 def test_predict_endpoint_handles_error():
@@ -44,13 +56,23 @@ def test_predict_endpoint_handles_error():
 
     with patch.dict(ml_models, {"model": broken_model}):
         payload = {
-            "CRIM": 0.1, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
-            "NOX": 0.538, "RM": 6.575, "AGE": 65.2, "DIS": 4.09,
-            "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.98
+            "CRIM": 0.1,
+            "ZN": 18.0,
+            "INDUS": 2.31,
+            "CHAS": 0.0,
+            "NOX": 0.538,
+            "RM": 6.575,
+            "AGE": 65.2,
+            "DIS": 4.09,
+            "RAD": 1,
+            "TAX": 296,
+            "PTRATIO": 15.3,
+            "B": 396.9,
+            "LSTAT": 4.98,
         }
-        
+
         response = client.post("/predict", json=payload)
-        
-        #Assertions
+
+        # Assertions
         assert response.status_code == 400
         assert "Model failure" in response.json()["detail"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,38 +1,56 @@
 # tests/test_api.py
-import os
 from fastapi.testclient import TestClient
-from src.api.main import app
+from unittest.mock import MagicMock, patch
+from src.api.main import app, ml_models
 
-def test_health_check():
-    with TestClient(app) as client:
-        response = client.get("/health")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "ok"
+client = TestClient(app)
+
+# Mocked successful prediction test
+def test_predict_endpoint_mocked_success():
+    """
+    Unit test of the /predict endpoint with a mocked successful model.
+    1. Create a fake model that always returns 25.0
+    2. Inject this fake model into the API's global model storage
+    """
+    fake_model = MagicMock()
+    fake_model.predict.return_value = [25.0] # Mock response
+
+    # Injection of fake model
+    # patch.dict replaces the 'ml_models' dict temporarily
+    with patch.dict(ml_models, {"model": fake_model}):
+        payload = {
+            "CRIM": 0.1, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
+            "NOX": 0.538, "RM": 6.575, "AGE": 65.2, "DIS": 4.09,
+            "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.98
+        }
         
-        expected_model_loaded = os.path.exists("models/model_pipeline.pkl")
-        assert data["model_loaded"] == expected_model_loaded
-
-def test_predict_valid_payload():
-    payload = {
-        "CRIM": 0.00632, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
-        "NOX": 0.538, "RM": 6.575, "AGE": 65.2, "DIS": 4.09,
-        "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.98
-    }
-    
-    with TestClient(app) as client:
-        if os.path.exists("models/model_pipeline.pkl"):
-            response = client.post("/predict", json=payload)
-            assert response.status_code == 200
-            data = response.json()
-            assert "predicted_price" in data
-            assert isinstance(data["predicted_price"], float)
-        else:
-            response = client.post("/predict", json=payload)
-            assert response.status_code == 500
-
-def test_predict_invalid_payload():
-    payload = {"CRIM": "esto no es un número"}
-    with TestClient(app) as client:
         response = client.post("/predict", json=payload)
-        assert response.status_code == 422
+        
+        assert response.status_code == 200
+        assert response.json() == {"predicted_price": 25.0}
+        # Verify that the model's predict method was called once
+        fake_model.predict.assert_called_once()
+
+# Failure case: Mock of a model that raises an exception
+def test_predict_endpoint_handles_error():
+    """
+    Test the /predict endpoint when the model raises an exception.
+    1. Create a fake model that raises an exception on predict
+    2. Inject this fake model into the API's global model storage
+    3. Verify that the API returns a 400 or 500 error code
+    """
+    broken_model = MagicMock()
+    broken_model.predict.side_effect = Exception("Model failure")
+
+    with patch.dict(ml_models, {"model": broken_model}):
+        payload = {
+            "CRIM": 0.1, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
+            "NOX": 0.538, "RM": 6.575, "AGE": 65.2, "DIS": 4.09,
+            "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.98
+        }
+        
+        response = client.post("/predict", json=payload)
+        
+        #Assertions
+        assert response.status_code == 400
+        assert "Model failure" in response.json()["detail"]

--- a/tests/test_core_ml.py
+++ b/tests/test_core_ml.py
@@ -5,27 +5,41 @@ import joblib
 import os
 import numpy as np
 
+
 def test_model_loading_and_prediction():
     """
     Strict test to ensure the model loads correctly and can make a prediction.
     """
     model_path = "models/model_pipeline.pkl"
-    
 
     if not os.path.exists(model_path):
         pytest.skip("No model file found. Skipping test.")
-        
+
     model = joblib.load(model_path)
-    
+
     # Dummy data to predict
-    input_data = pd.DataFrame([{
-        "CRIM": 0.01, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
-        "NOX": 0.53, "RM": 6.5, "AGE": 65.2, "DIS": 4.0,
-        "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.9
-    }])
-    
+    input_data = pd.DataFrame(
+        [
+            {
+                "CRIM": 0.01,
+                "ZN": 18.0,
+                "INDUS": 2.31,
+                "CHAS": 0.0,
+                "NOX": 0.53,
+                "RM": 6.5,
+                "AGE": 65.2,
+                "DIS": 4.0,
+                "RAD": 1,
+                "TAX": 296,
+                "PTRATIO": 15.3,
+                "B": 396.9,
+                "LSTAT": 4.9,
+            }
+        ]
+    )
+
     prediction = model.predict(input_data)
-    
+
     # Assertions
     assert isinstance(prediction[0], (float, np.floating))
-    assert prediction[0] > 0 
+    assert prediction[0] > 0

--- a/tests/test_core_ml.py
+++ b/tests/test_core_ml.py
@@ -1,0 +1,31 @@
+# tests/test_core_ml.py
+import pytest
+import pandas as pd
+import joblib
+import os
+import numpy as np
+
+def test_model_loading_and_prediction():
+    """
+    Strict test to ensure the model loads correctly and can make a prediction.
+    """
+    model_path = "models/model_pipeline.pkl"
+    
+
+    if not os.path.exists(model_path):
+        pytest.skip("No model file found. Skipping test.")
+        
+    model = joblib.load(model_path)
+    
+    # Dummy data to predict
+    input_data = pd.DataFrame([{
+        "CRIM": 0.01, "ZN": 18.0, "INDUS": 2.31, "CHAS": 0.0,
+        "NOX": 0.53, "RM": 6.5, "AGE": 65.2, "DIS": 4.0,
+        "RAD": 1, "TAX": 296, "PTRATIO": 15.3, "B": 396.9, "LSTAT": 4.9
+    }])
+    
+    prediction = model.predict(input_data)
+    
+    # Assertions
+    assert isinstance(prediction[0], (float, np.floating))
+    assert prediction[0] > 0 


### PR DESCRIPTION
## refactor(api): implement lifespan and separate unit/integration tests" -m "- Refactor FastAPI startup event to use modern 'lifespan' manager.

-Implement 'ml_models' global dictionary for easier mocking.

-Add mocked unit tests in 'test_api.py'.

-Add test_core_ml.py for strict model validation.

- Fix DeprecationWarnings for Pydantic and startup events.
